### PR TITLE
feat: add suspend treatment type

### DIFF
--- a/lib/sidekiq/antidote.rb
+++ b/lib/sidekiq/antidote.rb
@@ -9,6 +9,7 @@ require_relative "./antidote/middlewares/client"
 require_relative "./antidote/middlewares/server"
 require_relative "./antidote/remedy"
 require_relative "./antidote/repository"
+require_relative "./antidote/suspension_group"
 require_relative "./antidote/version"
 
 module Sidekiq

--- a/lib/sidekiq/antidote/inhibitor.rb
+++ b/lib/sidekiq/antidote/inhibitor.rb
@@ -38,7 +38,7 @@ module Sidekiq
       end
 
       def to_s
-        "#{treatment} #{class_qualifier}" + (treatment == "suspend" ? ": #{id}" : "")
+        "#{treatment} #{class_qualifier}"
       end
 
       def eql?(other)
@@ -46,26 +46,6 @@ module Sidekiq
           && id == other.id && treatment == other.treatment && class_qualifier == other.class_qualifier
       end
       alias == eql?
-
-      def apply(message)
-        case treatment
-        when "kill"
-          kill(message)
-        when "suspend"
-          suspend(message)
-        end
-      end
-
-      private
-
-      def kill(message)
-        DeadSet.new.kill(Sidekiq.dump_json(message))
-      end
-
-      def suspend(message)
-        puts id
-        SuspensionGroup.new(name: id).add(message: message)
-      end
     end
   end
 end

--- a/lib/sidekiq/antidote/inhibitor.rb
+++ b/lib/sidekiq/antidote/inhibitor.rb
@@ -46,6 +46,12 @@ module Sidekiq
           && id == other.id && treatment == other.treatment && class_qualifier == other.class_qualifier
       end
       alias == eql?
+
+      def suspension_group_size
+        return 0 unless treatment == "suspend"
+
+        SuspensionGroup.new(name: id).size
+      end
     end
   end
 end

--- a/lib/sidekiq/antidote/middlewares/shared.rb
+++ b/lib/sidekiq/antidote/middlewares/shared.rb
@@ -29,6 +29,8 @@ module Sidekiq
 
           case inhibitor.treatment
           when "kill" then DeadSet.new.kill(message)
+          when "suspend"
+            SuspensionGroup.new(name: inhibitor.id).add(message: message)
           end
         end
       end

--- a/lib/sidekiq/antidote/middlewares/shared.rb
+++ b/lib/sidekiq/antidote/middlewares/shared.rb
@@ -29,8 +29,7 @@ module Sidekiq
 
           case inhibitor.treatment
           when "kill" then DeadSet.new.kill(message)
-          when "suspend"
-            SuspensionGroup.new(name: inhibitor.id).add(message: message)
+          when "suspend" then SuspensionGroup.new(name: inhibitor.id).add(message: message)
           end
         end
       end

--- a/lib/sidekiq/antidote/suspension_group.rb
+++ b/lib/sidekiq/antidote/suspension_group.rb
@@ -49,6 +49,10 @@ module Sidekiq
       def add(message:)
         self.class.redis("LPUSH", @rname, Sidekiq.dump_json(message))
       end
+
+      def release!
+        self.class.redis("RENAME", @rname, "#{Repository::REDIS_KEY}:release:#{name}")
+      end
     end
   end
 end

--- a/lib/sidekiq/antidote/suspension_group.rb
+++ b/lib/sidekiq/antidote/suspension_group.rb
@@ -51,6 +51,8 @@ module Sidekiq
       end
 
       def release!
+        return unless self.class.redis("EXISTS", @rname) != 0
+
         self.class.redis("RENAME", @rname, "#{Repository::REDIS_KEY}:release:#{name}")
       end
     end

--- a/lib/sidekiq/antidote/suspension_group.rb
+++ b/lib/sidekiq/antidote/suspension_group.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  module Antidote
+    # Suspension groups for suspend treatment
+    class SuspensionGroup
+      include Enumerable
+
+      def self.all
+        redis("SSCAN", "suspension_groups", 0)[1].to_a.map { |sg| SuspensionGroup.new(name: sg) }
+      end
+
+      def self.redis(...)
+        Sidekiq.redis { _1.call(...) }
+      end
+
+      # @return [String]
+      attr_reader :name
+
+      def initialize(name:)
+        @name = name.to_s
+        @rname = "#{Repository::REDIS_KEY}:suspend:#{name}"
+      end
+
+      def size
+        @size ||= self.class.redis("LLEN", @rname)
+      end
+
+      def each(&block)
+        page = 0
+        page_size = 50
+
+        loop do
+          range_start = page * page_size
+          range_end = range_start + page_size - 1
+          entries = self.class.redis("LRANGE", @rname, range_start, range_end)
+
+          break if entries.empty?
+
+          page += 1
+          entries.each(&block)
+        end
+      end
+
+      def add(message:)
+        self.class.redis("SADD", "suspension_groups", name)
+        self.class.redis("LPUSH", @rname, Sidekiq.dump_json(message))
+      end
+    end
+  end
+end

--- a/lib/sidekiq/antidote/web.rb
+++ b/lib/sidekiq/antidote/web.rb
@@ -47,6 +47,10 @@ module Sidekiq
 
           redirect "#{root_path}antidote"
         end
+
+        app.post("/antidote/suspension-group/:id/delete") do
+          Sidekiq::Antidote::SuspensionGroup.new(name: route_params[:id]).release!
+        end
       end
     end
   end

--- a/lib/sidekiq/antidote/web.rb
+++ b/lib/sidekiq/antidote/web.rb
@@ -45,11 +45,9 @@ module Sidekiq
         app.post("/antidote/:id/delete") do
           Antidote.delete(route_params[:id])
 
-          redirect "#{root_path}antidote"
-        end
-
-        app.post("/antidote/suspension-group/:id/delete") do
           Sidekiq::Antidote::SuspensionGroup.new(name: route_params[:id]).release!
+
+          redirect "#{root_path}antidote"
         end
       end
     end

--- a/spec/sidekiq/antidote/inhibitor_spec.rb
+++ b/spec/sidekiq/antidote/inhibitor_spec.rb
@@ -103,13 +103,6 @@ RSpec.describe Sidekiq::Antidote::Inhibitor do
     subject { inhibitor.to_s }
 
     it { is_expected.to eq "#{treatment} #{class_qualifier}" }
-
-    context "when treatment is suspend" do
-      let(:treatment) { "suspend" }
-      let(:id)        { "one" }
-
-      it { is_expected.to eq "#{treatment} #{class_qualifier}: one" }
-    end
   end
 
   describe "#eql?" do
@@ -146,38 +139,6 @@ RSpec.describe Sidekiq::Antidote::Inhibitor do
   describe "#==" do
     it "is an alias of #eql?" do
       expect(inhibitor.method(:==)).to eq inhibitor.method(:eql?)
-    end
-  end
-
-  describe "#apply" do
-    subject { inhibitor.apply(message: job_message) }
-
-    let(:job_message) { simple_job_message(klass: "A::B::CJob") }
-
-    context "when treatment is skip" do
-      it "does not deliver job to morge" do
-        expect { subject }.to keep_unchanged(Sidekiq::DeadSet.new, :size)
-      end
-    end
-
-    context "when treatment is kill" do
-      let(:treatment) { "kill" }
-
-      it "delivers job to morgue" do
-        expect { subject }.to change(Sidekiq::DeadSet.new, :size)
-      end
-    end
-
-    context "when treatment is suspend" do
-      let(:treatment) { "suspend" }
-
-      it "does not deliver job to morge" do
-        expect { subject }.to keep_unchanged(Sidekiq::DeadSet.new, :size)
-      end
-
-      it "stores the job in suspension group" do
-        expect { subject }.to change { Sidekiq::Antidote::SuspensionGroup.new(name: id).size }.by(1)
-      end
     end
   end
 end

--- a/spec/sidekiq/antidote/inhibitor_spec.rb
+++ b/spec/sidekiq/antidote/inhibitor_spec.rb
@@ -141,4 +141,24 @@ RSpec.describe Sidekiq::Antidote::Inhibitor do
       expect(inhibitor.method(:==)).to eq inhibitor.method(:eql?)
     end
   end
+
+  describe "#suspension_group_size" do
+    let(:treatment) { "suspend" }
+
+    before do
+      redis_lpush("sidekiq-antidote:suspend:deadbeef", Sidekiq.dump_json(simple_job_message(klass: "DreamJob")))
+    end
+
+    it "returns the size of the suspension group" do
+      expect(subject.suspension_group_size).to eq(1)
+    end
+
+    context "when treatment is not suspend" do
+      let(:treatment) { "skip" }
+
+      it "returns 0" do
+        expect(subject.suspension_group_size).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/sidekiq/antidote/middlewares/server_spec.rb
+++ b/spec/sidekiq/antidote/middlewares/server_spec.rb
@@ -49,5 +49,31 @@ RSpec.describe Sidekiq::Antidote::Middlewares::Server do
           .to change(Sidekiq::DeadSet.new, :size)
       end
     end
+
+    context "when job matches <suspend> inhibitor" do
+      before do
+        allow(SecureRandom).to receive(:hex).and_return("group1")
+
+        Sidekiq::Antidote.add(treatment: "suspend", class_qualifier: "**TestJob")
+        Sidekiq::Antidote.configure { |c| c.refresh_rate = 0.1 }
+        Sidekiq::Antidote.startup
+        sleep 0.1
+      end
+
+      it "terminates chain execution" do
+        expect { |b| middleware.call(job_instance, job_message, Sidekiq.redis_pool, &b) }
+          .not_to yield_control
+      end
+
+      it "does not deliver job to morgue" do
+        expect { |b| middleware.call(job_instance, job_message, Sidekiq.redis_pool, &b) }
+          .to keep_unchanged(Sidekiq::DeadSet.new, :size)
+      end
+
+      it "stores job in suspend_group set" do
+        expect { |b| middleware.call(job_instance, job_message, Sidekiq.redis_pool, &b) }
+          .to change { Sidekiq::Antidote::SuspensionGroup.new(name: "group1").size }.by(1)
+      end
+    end
   end
 end

--- a/spec/sidekiq/antidote/repository_spec.rb
+++ b/spec/sidekiq/antidote/repository_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Sidekiq::Antidote::Repository do
     before do
       redis_hset("123", Sidekiq.dump_json(%w[kill A]))
       redis_hset("456", Sidekiq.dump_json(%w[skip B]))
+      redis_hset("789", Sidekiq.dump_json(%w[suspend C]))
       redis_hset("999", "broken")
     end
 
@@ -21,7 +22,8 @@ RSpec.describe Sidekiq::Antidote::Repository do
         change { yielded_results }.to(
           contain_exactly(
             Sidekiq::Antidote::Inhibitor.new(id: "123", treatment: "kill", class_qualifier: "A"),
-            Sidekiq::Antidote::Inhibitor.new(id: "456", treatment: "skip", class_qualifier: "B")
+            Sidekiq::Antidote::Inhibitor.new(id: "456", treatment: "skip", class_qualifier: "B"),
+            Sidekiq::Antidote::Inhibitor.new(id: "789", treatment: "suspend", class_qualifier: "C")
           )
         )
       )
@@ -31,7 +33,8 @@ RSpec.describe Sidekiq::Antidote::Repository do
       expect { subject }.to(
         change { redis_hgetall }.to({
           "123" => Sidekiq.dump_json(%w[kill A]),
-          "456" => Sidekiq.dump_json(%w[skip B])
+          "456" => Sidekiq.dump_json(%w[skip B]),
+          "789" => Sidekiq.dump_json(%w[suspend C])
         })
       )
     end
@@ -46,7 +49,8 @@ RSpec.describe Sidekiq::Antidote::Repository do
       it "returns each valid inhibitor" do
         expect(subject).to contain_exactly(
           Sidekiq::Antidote::Inhibitor.new(id: "123", treatment: "kill", class_qualifier: "A"),
-          Sidekiq::Antidote::Inhibitor.new(id: "456", treatment: "skip", class_qualifier: "B")
+          Sidekiq::Antidote::Inhibitor.new(id: "456", treatment: "skip", class_qualifier: "B"),
+          Sidekiq::Antidote::Inhibitor.new(id: "789", treatment: "suspend", class_qualifier: "C")
         )
       end
 
@@ -54,7 +58,8 @@ RSpec.describe Sidekiq::Antidote::Repository do
         expect { subject.to_a }.to(
           change { redis_hgetall }.to({
             "123" => Sidekiq.dump_json(%w[kill A]),
-            "456" => Sidekiq.dump_json(%w[skip B])
+            "456" => Sidekiq.dump_json(%w[skip B]),
+            "789" => Sidekiq.dump_json(%w[suspend C])
           })
         )
       end

--- a/spec/sidekiq/antidote/suspension_group_spec.rb
+++ b/spec/sidekiq/antidote/suspension_group_spec.rb
@@ -65,4 +65,18 @@ RSpec.describe Sidekiq::Antidote::SuspensionGroup do
       )
     end
   end
+
+  describe "#release!" do
+    let(:job_message) { simple_job_message(klass: "A::B::CJob") }
+
+    before do
+      redis_lpush("sidekiq-antidote:suspend:group1", Sidekiq.dump_json(job_message))
+    end
+
+    it "renames the suspend list to release" do
+      expect { suspension_group.release! }
+        .to change { redis_llen("sidekiq-antidote:suspend:group1") }.to(0)
+        .and change { redis_llen("sidekiq-antidote:release:group1") }.to(1)
+    end
+  end
 end

--- a/spec/sidekiq/antidote/suspension_group_spec.rb
+++ b/spec/sidekiq/antidote/suspension_group_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe Sidekiq::Antidote::SuspensionGroup do
     subject { described_class.all }
 
     before do
-      redis_sadd(%w[group1 group2 group3])
       redis_lpush("sidekiq-antidote:suspend:group1", Sidekiq.dump_json(simple_job_message(klass: "A::B::CJob")))
+      redis_lpush("sidekiq-antidote:suspend:group2", Sidekiq.dump_json(simple_job_message(klass: "A::B::CJob")))
+      redis_lpush("sidekiq-antidote:suspend:group3", Sidekiq.dump_json(simple_job_message(klass: "A::B::CJob")))
     end
 
     it "returns all suspension groups" do
@@ -62,24 +63,6 @@ RSpec.describe Sidekiq::Antidote::SuspensionGroup do
       expect { suspension_group.add(message: job_message) }.to(
         change { redis_llen("sidekiq-antidote:suspend:group1") }.from(1).to(2)
       )
-    end
-
-    it "adds a suspension group to redis" do
-      expect { suspension_group.add(message: job_message) }.to(
-          change { redis_scard("suspension_groups") }.from(0).to(1)
-        )
-    end
-
-    context "when suspension group already exists" do
-      before do
-        redis_sadd(name)
-      end
-
-      it "does not add a suspension group to redis" do
-        expect { suspension_group.add(message: job_message) }.to(
-            keep_unchanged { redis_scard("suspension_groups") }
-          )
-      end
     end
   end
 end

--- a/spec/sidekiq/antidote/suspension_group_spec.rb
+++ b/spec/sidekiq/antidote/suspension_group_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe Sidekiq::Antidote::SuspensionGroup do
+  subject(:suspension_group) { described_class.new(name: name) }
+
+  let(:name) { "group1" }
+
+  it { is_expected.to be_an Enumerable }
+
+  describe ".all" do
+    subject { described_class.all }
+
+    before do
+      redis_sadd(%w[group1 group2 group3])
+      redis_lpush("sidekiq-antidote:suspend:group1", Sidekiq.dump_json(simple_job_message(klass: "A::B::CJob")))
+    end
+
+    it "returns all suspension groups" do
+      expect(subject).to include(
+        an_object_having_attributes(name: "group1"),
+        an_object_having_attributes(name: "group2"),
+        an_object_having_attributes(name: "group3")
+      )
+
+      expect(subject.first.size).to eq(1)
+    end
+  end
+
+  describe "#each" do
+    subject { suspension_group.each { |job_message| yielded_results << job_message } }
+
+    let(:yielded_results) { [] }
+    let(:job_message)     { simple_job_message(klass: "A::B::CJob") }
+
+    before do
+      redis_lpush("sidekiq-antidote:suspend:group1", Sidekiq.dump_json(job_message))
+      redis_lpush("sidekiq-antidote:suspend:group1", Sidekiq.dump_json(job_message))
+      redis_lpush("sidekiq-antidote:suspend:group1", Sidekiq.dump_json(job_message))
+    end
+
+    it "yields each valid inhibitor" do
+      expect { subject }.to(
+        change { yielded_results }.to(
+          contain_exactly(
+            Sidekiq.dump_json(job_message),
+            Sidekiq.dump_json(job_message),
+            Sidekiq.dump_json(job_message)
+          )
+        )
+      )
+    end
+  end
+
+  describe "#add" do
+    let(:job_message) { simple_job_message(klass: "A::B::CJob") }
+
+    before do
+      redis_lpush("sidekiq-antidote:suspend:group1", Sidekiq.dump_json(job_message))
+    end
+
+    it "adds job message to redis" do
+      expect { suspension_group.add(message: job_message) }.to(
+        change { redis_llen("sidekiq-antidote:suspend:group1") }.from(1).to(2)
+      )
+    end
+
+    it "adds a suspension group to redis" do
+      expect { suspension_group.add(message: job_message) }.to(
+          change { redis_scard("suspension_groups") }.from(0).to(1)
+        )
+    end
+
+    context "when suspension group already exists" do
+      before do
+        redis_sadd(name)
+      end
+
+      it "does not add a suspension group to redis" do
+        expect { suspension_group.add(message: job_message) }.to(
+            keep_unchanged { redis_scard("suspension_groups") }
+          )
+      end
+    end
+  end
+end

--- a/spec/sidekiq/antidote/web_spec.rb
+++ b/spec/sidekiq/antidote/web_spec.rb
@@ -36,8 +36,9 @@ RSpec.describe Sidekiq::Antidote::Web, type: :feature do
   end
 
   it "lists registered inhibitors" do
-    alpha_inhibitor = Sidekiq::Antidote.add(treatment: "skip", class_qualifier: "AlphaJob")
-    beta_inhibitor  = Sidekiq::Antidote.add(treatment: "kill", class_qualifier: "BetaJob")
+    alpha_inhibitor    = Sidekiq::Antidote.add(treatment: "skip", class_qualifier: "AlphaJob")
+    beta_inhibitor     = Sidekiq::Antidote.add(treatment: "kill", class_qualifier: "BetaJob")
+    charlie_inhibitor  = Sidekiq::Antidote.add(treatment: "suspend", class_qualifier: "CharlieJob")
 
     visit("/antidote")
 
@@ -48,6 +49,10 @@ RSpec.describe Sidekiq::Antidote::Web, type: :feature do
     expect(find("tr#antidote-inhibitor-#{beta_inhibitor.id}"))
       .to have_css("td", text: "kill")
       .and have_css("td", text: "BetaJob")
+
+    expect(find("tr#antidote-inhibitor-#{charlie_inhibitor.id}"))
+      .to have_css("td", text: "suspend")
+      .and have_css("td", text: "CharlieJob")
   end
 
   describe "adding inhibitors" do
@@ -89,6 +94,21 @@ RSpec.describe Sidekiq::Antidote::Web, type: :feature do
       expect(page).to have_current_path("/antidote")
     end
 
+    it "allows adding <suspend> inhibitors" do
+      within("form#antidote-inhibitor") do
+        choose("antidote-inhibitor-treatment-suspend")
+        fill_in("class_qualifier", with: "**Job")
+        click_button("Submit")
+      end
+
+      expect(Sidekiq::Antidote.inhibitors).to contain_exactly(
+        have_attributes(treatment: "skip", class_qualifier: Sidekiq::Antidote::ClassQualifier.new("AlphaJob")),
+        have_attributes(treatment: "suspend", class_qualifier: Sidekiq::Antidote::ClassQualifier.new("**Job"))
+      )
+
+      expect(page).to have_current_path("/antidote")
+    end
+
     it "shows error when class qualifier is invalid" do
       within("form#antidote-inhibitor") do
         choose("antidote-inhibitor-treatment-skip")
@@ -121,6 +141,25 @@ RSpec.describe Sidekiq::Antidote::Web, type: :feature do
       expect(Sidekiq::Antidote.inhibitors).to contain_exactly(
         have_attributes(treatment: "skip", class_qualifier: Sidekiq::Antidote::ClassQualifier.new("AlphaJob"))
       )
+    end
+  end
+
+  describe "releasing suspension groups" do
+    before do
+      allow(SecureRandom).to receive(:hex).and_return("abc")
+      inhibitor = Sidekiq::Antidote.add(treatment: "suspend", class_qualifier: "AlphaJob")
+
+      redis_lpush("sidekiq-antidote:suspend:abc", Sidekiq.dump_json(simple_job_message(klass: "AlphaJob")))
+
+      visit("/antidote")
+      within("tr#antidote-inhibitor-#{CGI.escape(inhibitor.id)}") do
+        click_button("delete")
+      end
+    end
+
+    it "renames the suspension group" do
+      expect(redis_llen("sidekiq-antidote:suspend:abc")).to eq(0)
+      expect(redis_llen("sidekiq-antidote:release:abc")).to eq(1)
     end
   end
 end

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -41,6 +41,22 @@ module AntidoteTesting
   def redis_hset(field, value)
     Sidekiq.redis { _1.call("HSET", "sidekiq-antidote", field, value) }
   end
+
+  def redis_lpush(key, value)
+    Sidekiq.redis { _1.call("LPUSH", key, value) }
+  end
+
+  def redis_llen(key)
+    Sidekiq.redis { _1.call("LLEN", key) }
+  end
+
+  def redis_scard(key)
+    Sidekiq.redis { _1.call("SCARD", key) }
+  end
+
+  def redis_sadd(member)
+    Sidekiq.redis { _1.call("SADD", "suspension_groups", member) }
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -53,10 +53,6 @@ module AntidoteTesting
   def redis_scard(key)
     Sidekiq.redis { _1.call("SCARD", key) }
   end
-
-  def redis_sadd(member)
-    Sidekiq.redis { _1.call("SADD", "suspension_groups", member) }
-  end
 end
 
 RSpec.configure do |config|

--- a/web/views/add.html.erb
+++ b/web/views/add.html.erb
@@ -23,6 +23,12 @@
           kill <em class="text-muted">(send to the dead set instead of enqueueing and/or performing)</em>
         </label>
       </div>
+      <div class="radio col-sm-offset-2 col-sm-10">
+        <label>
+          <input id="antidote-inhibitor-treatment-suspend" type="radio" name="treatment" value="suspend" <%= "checked" if "suspend" == @treatment %>>
+          suspend <em class="text-muted">(hold off enqueue and/or perform)</em>
+        </label>
+      </div>
     </div>
     <div class="form-group <%= "has-error" if @class_qualifier_error %>">
       <label class="col-sm-2 control-label"><%= t("antidote.class_qualifier") %></label>

--- a/web/views/index.html.erb
+++ b/web/views/index.html.erb
@@ -18,7 +18,12 @@
       <tbody>
         <% @inhibitors.each do |inhibitor| %>
           <tr id="antidote-inhibitor-<%= CGI.escape(inhibitor.id) %>">
-            <td><%= inhibitor.treatment %></td>
+            <td width="25%">
+              <%= inhibitor.treatment %>
+              <% if inhibitor.treatment == "suspend" %>
+                <em class="text-muted" style="margin-left: 10px"> Jobs suspended: <%= inhibitor.suspension_group_size %> </em>
+              <% end %>
+            </td>
             <td><%= inhibitor.class_qualifier.pattern %></td>
             <td class="delete-confirm">
               <form action="<%=root_path %>antidote/<%= CGI.escape(inhibitor.id) %>/delete" method="post">


### PR DESCRIPTION
# Change
Perhaps users might want to postpone a specific job, rather than swallow the jobs without handling them at all. `postpone` will skip the execution of the job, and store it in a SuspensionGroup.

Users can flush or delete the inhiibitor
- 'flush': flush all jobs in the SuspensionGroup to their respective queues
- 'delete': clear the SuspensionGroup without handling the jobs

# Notes
* Suspension groups will be saved under: 'sidekiq-antidote:suspend:inhibitor_id`
* We can tie suspension groups with the inhibtor class_qualifier so that users can no semantically what the suspension grou pmeans