### PR TITLE
refactor: Ensure poison pill has queue name

### DIFF
--- a/lib/sidekiq/antidote/middlewares/client.rb
+++ b/lib/sidekiq/antidote/middlewares/client.rb
@@ -11,8 +11,8 @@ module Sidekiq
 
         # @see https://github.com/sidekiq/sidekiq/wiki/Middleware
         # @see https://github.com/sidekiq/sidekiq/wiki/Job-Format
-        def call(_, job_payload, _, _)
-          yield unless inhibit(job_payload)
+        def call(_, job_payload, queue_name, _)
+          yield unless inhibit(job_payload, queue_name)
         end
       end
     end

--- a/lib/sidekiq/antidote/middlewares/server.rb
+++ b/lib/sidekiq/antidote/middlewares/server.rb
@@ -11,8 +11,8 @@ module Sidekiq
 
         # @see https://github.com/sidekiq/sidekiq/wiki/Middleware
         # @see https://github.com/sidekiq/sidekiq/wiki/Job-Format
-        def call(_, job_payload, _)
-          yield unless inhibit(job_payload)
+        def call(_, job_payload, queue_name)
+          yield unless inhibit(job_payload, queue_name)
         end
       end
     end


### PR DESCRIPTION
This patch also adds apply_treatment method that can be enriched with suspend logic (see: https://github.com/ixti/sidekiq-antidote/pull/6).
